### PR TITLE
Added Response class, Match HandleRequest API, other minor refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ CXX=g++
 CXXFLAGS=-std=c++11 -I. -Wall -Werror
 OPTIMIZE=-O2
 BOOSTFLAG = -lboost_system -lboost_regex
-DEPS=server.h connection.h config_parser.h request.h request_handler.h echo_handler.h file_handler.h not_found_handler.h
-OBJ=server.o connection.o config_parser.o request.o echo_handler.o file_handler.o not_found_handler.o
+DEPS=server.h connection.h config_parser.h request.h response.h request_handler.h echo_handler.h file_handler.h not_found_handler.h
+OBJ=server.o connection.o config_parser.o request.o response.o echo_handler.o file_handler.o not_found_handler.o
 GTEST_DIR=googletest/googletest
 TESTS=config_parser_test connection_test server_test request_test echo_handler_test file_handler_test not_found_handler_test
 

--- a/connection.cc
+++ b/connection.cc
@@ -44,11 +44,17 @@ void Connection::handle_request(const boost::system::error_code& error, size_t b
 		if (handler == nullptr) {
 			// TODO generalize, fit with the StaticFileHandler
 			NotFoundHandler not_found_handler("Bad Path");
-			response = not_found_handler.HandleRequest(*request);
+			not_found_handler.HandleRequest(*request, &response);
 		}
 		else {
 			// have the handler generate a response
-			response = handler->HandleRequest(*request);
+			RequestHandler::Status status = handler->HandleRequest(*request, &response);
+			if(status != RequestHandler::OK)
+			{
+				response = Response();
+				response.SetStatus(Response::internal_server_error);
+				response.SetBody("500 Internal Server Error");
+			}
 		}
 
 		// write out the response

--- a/connection.h
+++ b/connection.h
@@ -20,7 +20,7 @@ public:
 
 	void handle_request(const boost::system::error_code& error, size_t bytes_transferred);
 
-	std::string write_response(std::string data);
+	std::string write_response(const Response& response);
 
 private:
 	// Close socket after sending response

--- a/connection_test.cc
+++ b/connection_test.cc
@@ -2,13 +2,23 @@
 
 #include "gtest/gtest.h"
 #include "connection.h"
+#include "response.h"
 
 
 TEST(ConnectionTest, SimpleString) {
 	boost::asio::io_service io_service;
 	HandlerContainer *handlers = new HandlerContainer();
 	Connection c = Connection(io_service, handlers);
-	std::string response = c.write_response("hello");
-	std::string expect = "hello";
-	EXPECT_EQ(response, expect);
+
+	std::string body = "hello";
+
+	Response response;
+	response.SetStatus(Response::ok);
+	response.AddHeader("Content-Type", "text/plain");
+	response.AddHeader("Content-Length", std::to_string(body.length()));
+	response.SetBody(body);
+
+	std::string response_result = c.write_response(response);
+	std::string expect = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello";
+	EXPECT_EQ(response_result, expect);
 }

--- a/echo_handler.cc
+++ b/echo_handler.cc
@@ -1,14 +1,15 @@
 #include <string>
-#include <sstream>
 
 #include "request_handler.h"
 #include "echo_handler.h"
+#include "response.h"
 
-std::string EchoHandler::HandleRequest(const Request& request) const
+Response EchoHandler::HandleRequest(const Request& request) const
 {
-	std::stringstream ss;
-	ss << "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: " << request.raw_request().length() << "\r\n\r\n";
-	ss << request.raw_request(); // the echo, includes the header
-
-	return ss.str();
+	Response response;
+	response.SetStatus(Response::ok);
+	response.AddHeader("Content-Type", "text/plain");
+	response.AddHeader("Content-Length", std::to_string(request.raw_request().length()));
+	response.SetBody(request.raw_request());
+	return response;
 }

--- a/echo_handler.cc
+++ b/echo_handler.cc
@@ -4,12 +4,11 @@
 #include "echo_handler.h"
 #include "response.h"
 
-Response EchoHandler::HandleRequest(const Request& request) const
+RequestHandler::Status EchoHandler::HandleRequest(const Request& request, Response* response) const
 {
-	Response response;
-	response.SetStatus(Response::ok);
-	response.AddHeader("Content-Type", "text/plain");
-	response.AddHeader("Content-Length", std::to_string(request.raw_request().length()));
-	response.SetBody(request.raw_request());
-	return response;
+	response->SetStatus(Response::ok);
+	response->AddHeader("Content-Type", "text/plain");
+	response->AddHeader("Content-Length", std::to_string(request.raw_request().length()));
+	response->SetBody(request.raw_request());
+	return RequestHandler::OK;
 }

--- a/echo_handler.h
+++ b/echo_handler.h
@@ -10,8 +10,7 @@
 
 class EchoHandler : public RequestHandler {
 public:
-	
-	virtual Response HandleRequest(const Request& request) const;
+	virtual RequestHandler::Status HandleRequest(const Request& request, Response* response) const;
 	
 };
 

--- a/echo_handler.h
+++ b/echo_handler.h
@@ -6,11 +6,12 @@
 #include "request_handler.h"
 #include "config_parser.h"
 #include "request.h"
+#include "response.h"
 
 class EchoHandler : public RequestHandler {
 public:
 	
-	virtual std::string HandleRequest(const Request& request) const;
+	virtual Response HandleRequest(const Request& request) const;
 	
 };
 

--- a/echo_handler_test.cc
+++ b/echo_handler_test.cc
@@ -13,7 +13,8 @@ TEST(EchoHandlerTest, SimpleString) {
 	// create an echo handler
 	EchoHandler echoHandler;
 
-	Response response = echoHandler.HandleRequest(*request);
+	Response response;
+	echoHandler.HandleRequest(*request, &response);
 	std::string response_string = response.ToString();
 
 	std::string expected = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello";

--- a/echo_handler_test.cc
+++ b/echo_handler_test.cc
@@ -13,7 +13,9 @@ TEST(EchoHandlerTest, SimpleString) {
 	// create an echo handler
 	EchoHandler echoHandler;
 
-	std::string response = echoHandler.HandleRequest(*request);
+	Response response = echoHandler.HandleRequest(*request);
+	std::string response_string = response.ToString();
+
 	std::string expected = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello";
-	EXPECT_EQ(response, expected);
+	EXPECT_EQ(response_string, expected);
 }

--- a/file_handler.h
+++ b/file_handler.h
@@ -13,7 +13,7 @@ public:
 	FileHandler(const std::string& directory);
 	// data is the full http request
 	// request is the parsed request
-	virtual Response HandleRequest(const Request& request) const;
+	virtual RequestHandler::Status HandleRequest(const Request& request, Response* response) const;
 
 private:
 	enum { max_length = 8192 };

--- a/file_handler.h
+++ b/file_handler.h
@@ -2,18 +2,18 @@
 #define FILE_HANDLER_H
 
 #include <string>
-#include <memory>
 #include <unordered_map>
 #include "request_handler.h"
 #include "config_parser.h"
 #include "request.h"
+#include "response.h"
 
 class FileHandler : public RequestHandler {
 public:
 	FileHandler(const std::string& directory);
 	// data is the full http request
 	// request is the parsed request
-	virtual std::string HandleRequest(const Request& request) const;
+	virtual Response HandleRequest(const Request& request) const;
 
 private:
 	enum { max_length = 8192 };

--- a/file_handler_test.cc
+++ b/file_handler_test.cc
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 #include "file_handler.h"
 #include "request.h"
+#include "response.h"
 
 TEST(FileHandlerTest, SimpleTest) {
 	std::string raw_req = "GET /static/kinkakuji.jpg HTTP/1.1\r\n\r\n";
@@ -13,10 +14,11 @@ TEST(FileHandlerTest, SimpleTest) {
 	// create an echo handler
 	FileHandler fileHandler("static/");
 
-	std::string response = fileHandler.HandleRequest(*request);
+	Response response = fileHandler.HandleRequest(*request);
+	std::string response_string = response.ToString();
 	
-	int index = response.find("\r\n");
-	EXPECT_EQ(response.substr(0, index), "HTTP/1.1 200 OK");
+	int index = response_string.find("\r\n");
+	EXPECT_EQ(response_string.substr(0, index), "HTTP/1.1 200 OK");
 }
 
 TEST(FileHandlerTest, Simple404Test) {
@@ -28,10 +30,11 @@ TEST(FileHandlerTest, Simple404Test) {
 	// create an echo handler
 	FileHandler fileHandler("static/");
 
-	std::string response = fileHandler.HandleRequest(*request);
-	
-	int index = response.find("\r\n");
-	EXPECT_EQ(response.substr(0, index), "HTTP/1.1 404 Not Found");
+	Response response = fileHandler.HandleRequest(*request);
+	std::string response_string = response.ToString();
+
+	int index = response_string.find("\r\n");
+	EXPECT_EQ(response_string.substr(0, index), "HTTP/1.1 404 Not Found");
 }
 
 TEST(FileHandlerTest, UnsupportedTest) {
@@ -40,8 +43,9 @@ TEST(FileHandlerTest, UnsupportedTest) {
 
 	FileHandler fileHandler("static/");
 
-	std::string response = fileHandler.HandleRequest(*request);
+	Response response = fileHandler.HandleRequest(*request);
+	std::string response_string = response.ToString();
 
-	int index = response.find("\r\n");
-	EXPECT_EQ(response.substr(0, index), "HTTP/1.1 404 Not Found");
+	int index = response_string.find("\r\n");
+	EXPECT_EQ(response_string.substr(0, index), "HTTP/1.1 404 Not Found");
 }

--- a/file_handler_test.cc
+++ b/file_handler_test.cc
@@ -14,7 +14,8 @@ TEST(FileHandlerTest, SimpleTest) {
 	// create an echo handler
 	FileHandler fileHandler("static/");
 
-	Response response = fileHandler.HandleRequest(*request);
+	Response response;
+	fileHandler.HandleRequest(*request, &response);
 	std::string response_string = response.ToString();
 	
 	int index = response_string.find("\r\n");
@@ -30,7 +31,8 @@ TEST(FileHandlerTest, Simple404Test) {
 	// create an echo handler
 	FileHandler fileHandler("static/");
 
-	Response response = fileHandler.HandleRequest(*request);
+	Response response;
+	fileHandler.HandleRequest(*request, &response);
 	std::string response_string = response.ToString();
 
 	int index = response_string.find("\r\n");
@@ -43,7 +45,8 @@ TEST(FileHandlerTest, UnsupportedTest) {
 
 	FileHandler fileHandler("static/");
 
-	Response response = fileHandler.HandleRequest(*request);
+	Response response;
+	fileHandler.HandleRequest(*request, &response);
 	std::string response_string = response.ToString();
 
 	int index = response_string.find("\r\n");

--- a/not_found_handler.cc
+++ b/not_found_handler.cc
@@ -1,15 +1,20 @@
 #include <string>
-#include <sstream>
 
 #include "request_handler.h"
 #include "not_found_handler.h"
+#include "response.h"
 
-std::string NotFoundHandler::HandleRequest(const Request& request) const
+// Constructor to have reason
+NotFoundHandler::NotFoundHandler(const std::string& reason) : reason_(reason) {}
+
+Response NotFoundHandler::HandleRequest(const Request& request) const
 {
-	std::string reason = "404 NOT FOUND\r\n";
-	std::stringstream ss;
-	ss << "HTTP/1.1 404 Not Found\r\nContent-Type: text/html\r\nContent-Length: " << reason.length() << "\r\n\r\n";
-	ss << reason;
-
-	return ss.str();
+	std::string reason = "404 NOT FOUND\r\n" + reason_;
+	
+	Response response;
+	response.SetStatus(Response::not_found);
+	response.AddHeader("Content-Type", "text/html");
+	response.AddHeader("Content-Length", std::to_string(reason.length()));
+	response.SetBody(reason);
+	return response;
 }

--- a/not_found_handler.cc
+++ b/not_found_handler.cc
@@ -7,14 +7,13 @@
 // Constructor to have reason
 NotFoundHandler::NotFoundHandler(const std::string& reason) : reason_(reason) {}
 
-Response NotFoundHandler::HandleRequest(const Request& request) const
+RequestHandler::Status NotFoundHandler::HandleRequest(const Request& request, Response* response) const
 {
 	std::string reason = "404 NOT FOUND\r\n" + reason_;
 	
-	Response response;
-	response.SetStatus(Response::not_found);
-	response.AddHeader("Content-Type", "text/html");
-	response.AddHeader("Content-Length", std::to_string(reason.length()));
-	response.SetBody(reason);
-	return response;
+	response->SetStatus(Response::not_found);
+	response->AddHeader("Content-Type", "text/html");
+	response->AddHeader("Content-Length", std::to_string(reason.length()));
+	response->SetBody(reason);
+	return RequestHandler::OK;
 }

--- a/not_found_handler.h
+++ b/not_found_handler.h
@@ -6,12 +6,15 @@
 #include "request_handler.h"
 #include "config_parser.h"
 #include "request.h"
+#include "response.h"
 
 class NotFoundHandler : public RequestHandler {
 public:
-	
-	virtual std::string HandleRequest(const Request& request) const;
-	
+	NotFoundHandler(const std::string& reason);
+	virtual Response HandleRequest(const Request& request) const;
+
+private:
+	std::string reason_;
 };
 
 

--- a/not_found_handler.h
+++ b/not_found_handler.h
@@ -11,7 +11,7 @@
 class NotFoundHandler : public RequestHandler {
 public:
 	NotFoundHandler(const std::string& reason);
-	virtual Response HandleRequest(const Request& request) const;
+	virtual RequestHandler::Status HandleRequest(const Request& request, Response* response) const;
 
 private:
 	std::string reason_;

--- a/not_found_handler_test.cc
+++ b/not_found_handler_test.cc
@@ -9,9 +9,11 @@ TEST(NotFoundHandlerTest, SimpleString) {
 	// generate header info from the request
 	auto request = Request::Parse(raw_req.c_str());
 	// create an echo handler
-	NotFoundHandler not_found_handler;
+	NotFoundHandler not_found_handler("");
 
-	std::string response = not_found_handler.HandleRequest(*request);
+	Response response = not_found_handler.HandleRequest(*request);
+	std::string response_string = response.ToString();
+
 	std::string expected = "HTTP/1.1 404 Not Found\r\nContent-Type: text/html\r\nContent-Length: 15\r\n\r\n404 NOT FOUND\r\n";
-	EXPECT_EQ(response, expected);
+	EXPECT_EQ(response_string, expected);
 }

--- a/not_found_handler_test.cc
+++ b/not_found_handler_test.cc
@@ -11,7 +11,8 @@ TEST(NotFoundHandlerTest, SimpleString) {
 	// create an echo handler
 	NotFoundHandler not_found_handler("");
 
-	Response response = not_found_handler.HandleRequest(*request);
+	Response response;
+	not_found_handler.HandleRequest(*request, &response);
 	std::string response_string = response.ToString();
 
 	std::string expected = "HTTP/1.1 404 Not Found\r\nContent-Type: text/html\r\nContent-Length: 15\r\n\r\n404 NOT FOUND\r\n";

--- a/request.cc
+++ b/request.cc
@@ -1,9 +1,9 @@
-#include "request.h"
 #include <string>
 #include <vector>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
+#include "request.h"
 
 Request::Request(std::string raw_req) : raw_request_(raw_req) { }
 

--- a/request_handler.h
+++ b/request_handler.h
@@ -2,7 +2,7 @@
 #define REQUEST_HANDLER_H
 
 #include <string>
-#include <list>
+#include <map>
 #include <memory>
 #include "request.h"
 #include "response.h"
@@ -19,8 +19,7 @@ public:
 	virtual RequestHandler::Status HandleRequest(const Request& request, Response* response) const = 0;
 };
 
-// list of k,v pairs, where k = path and v = pointer to request handler
-typedef std::list<std::pair<const std::string, std::unique_ptr<RequestHandler>>> HandlerContainer;
-typedef std::pair<const std::string, std::unique_ptr<RequestHandler>> HandlerPair;
+// map of k,v pairs, where k = path and v = pointer to request handler
+typedef std::map<const std::string, std::unique_ptr<RequestHandler>> HandlerContainer;
 
 #endif // REQUEST_HANDLER_H

--- a/request_handler.h
+++ b/request_handler.h
@@ -5,23 +5,14 @@
 #include <list>
 #include <memory>
 #include "request.h"
+#include "response.h"
 
 class RequestHandler {
 public:
 
 	// requestData is the full http request
 	// request is the parsed header
-	virtual std::string HandleRequest(const Request& request) const = 0;
-
-	static std::string generate_error(std::string reason)
-	{
-		reason = "404 NOT FOUND\r\n" + reason;
-		std::stringstream error_ss;
-		error_ss << "HTTP/1.1 404 Not Found\r\nContent-Type: text/html\r\nContent-Length: " << reason.length() << "\r\n\r\n";
-		error_ss << reason;
-
-		return error_ss.str();
-	}
+	virtual Response HandleRequest(const Request& request) const = 0;
 };
 
 // list of k,v pairs, where k = path and v = pointer to request handler

--- a/request_handler.h
+++ b/request_handler.h
@@ -9,10 +9,14 @@
 
 class RequestHandler {
 public:
+	enum Status {
+		OK = 0,
+		ERROR = 1
+	};
 
 	// requestData is the full http request
 	// request is the parsed header
-	virtual Response HandleRequest(const Request& request) const = 0;
+	virtual RequestHandler::Status HandleRequest(const Request& request, Response* response) const = 0;
 };
 
 // list of k,v pairs, where k = path and v = pointer to request handler

--- a/response.cc
+++ b/response.cc
@@ -1,0 +1,47 @@
+#include <iostream>
+#include <string>
+#include <sstream>
+#include "response.h"
+
+// Status lines for status codes
+namespace status_string {
+	const std::string ok = "HTTP/1.1 200 OK\r\n";
+	const std::string not_found = "HTTP/1.1 404 Not Found\r\n";
+}
+
+void Response::SetStatus(const ResponseCode response_code)
+{
+	switch(response_code)
+	{
+	case Response::ok:
+		response_status_string_ = status_string::ok;
+		break;
+	case Response::not_found:
+		response_status_string_ = status_string::not_found;
+		break;
+	}
+}
+
+void Response::AddHeader(const std::string& header_name, const std::string& header_value)
+{
+	response_headers_.push_back(std::make_pair(header_name, header_value));
+}
+
+void Response::SetBody(const std::string& body)
+{
+	body_ = body;
+}
+
+std::string Response::ToString() const
+{
+	std::stringstream ss;
+	ss << response_status_string_;
+	for(auto response_header : response_headers_)
+	{
+		ss << response_header.first << ": " << response_header.second << "\r\n";
+	}
+	ss << "\r\n";
+	ss << body_;
+
+	return ss.str();
+}

--- a/response.cc
+++ b/response.cc
@@ -7,6 +7,7 @@
 namespace status_string {
 	const std::string ok = "HTTP/1.1 200 OK\r\n";
 	const std::string not_found = "HTTP/1.1 404 Not Found\r\n";
+	const std::string internal_server_error = "HTTP/1.1 500 Internal Server Error\r\n";
 }
 
 void Response::SetStatus(const ResponseCode response_code)
@@ -18,6 +19,9 @@ void Response::SetStatus(const ResponseCode response_code)
 		break;
 	case Response::not_found:
 		response_status_string_ = status_string::not_found;
+		break;
+	case Response::internal_server_error:
+		response_status_string_ = status_string::internal_server_error;
 		break;
 	}
 }

--- a/response.h
+++ b/response.h
@@ -19,7 +19,8 @@ class Response {
 public:
 	enum ResponseCode {
 		ok = 200,
-        not_found = 404
+        not_found = 404,
+        internal_server_error = 500
 	};
 
 	void SetStatus(const ResponseCode response_code);

--- a/response.h
+++ b/response.h
@@ -1,0 +1,37 @@
+#ifndef RESPONSE_H
+#define RESPONSE_H
+
+// Represents an HTTP response.
+//
+// Usage:
+//   Response r;
+//   r.SetStatus(RESPONSE_200);
+//   r.SetBody(...);
+//   return r.ToString();
+//
+// Constructed by the RequestHandler, after which the server should call ToString
+// to serialize.
+
+#include <string>
+#include <vector>
+
+class Response {
+public:
+	enum ResponseCode {
+		ok = 200,
+        not_found = 404
+	};
+
+	void SetStatus(const ResponseCode response_code);
+	void AddHeader(const std::string& header_name, const std::string& header_value);
+	void SetBody(const std::string& body);
+
+	std::string ToString() const;
+
+private:
+	std::vector<std::pair<std::string, std::string>> response_headers_;
+	std::string response_status_string_;
+	std::string body_;
+};
+
+#endif // RESPONSE_H

--- a/server.cc
+++ b/server.cc
@@ -26,14 +26,14 @@ Server* Server::MakeServer(boost::asio::io_service& io_service, NginxConfig& out
 	std::shared_ptr<std::vector<std::string>> echo_paths = out_config.GetEchoPaths();
 	for(auto echo_path : *echo_paths)
 	{
-		handlers->push_back(HandlerPair(echo_path, std::unique_ptr<RequestHandler>(new EchoHandler())));
+		handlers->insert(std::make_pair(echo_path, std::unique_ptr<RequestHandler>(new EchoHandler())));
 	}
 
 	// Populate file server paths
 	std::shared_ptr<std::map<std::string, std::string>> file_paths = out_config.GetFilePaths();
 	for(auto file_path : *file_paths)
 	{
-		handlers->push_back(HandlerPair(file_path.first, std::unique_ptr<RequestHandler>(new FileHandler(file_path.second))));
+		handlers->insert(std::make_pair(file_path.first, std::unique_ptr<RequestHandler>(new FileHandler(file_path.second))));
 	}
 
 	return new Server(io_service, port, handlers);


### PR DESCRIPTION
1. Added Response Class for an object for responses instead of one string
2. Match RequestHandler's HandleRequest parameters to match specified API, with Status return and Request and Response parameters
3. Added response types for 200 OK, 404 Not Found, and 500 Internal Server Error
4. Minor refactor for HandlerContainer from list to map

TODO
1. constructor magic for request handlers along with Init
2. merge with new config which requires RequestHandler to create itself from given config block