### PR TITLE
Config path_regex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ CXX=g++
 CXXFLAGS=-std=c++11 -I. -Wall -Werror -static-libgcc -static-libstdc++ -pthread -Wl,-Bstatic
 LDLIBS= -lboost_log_setup -lboost_log -lboost_thread -lboost_regex -lboost_system
 OPTIMIZE=-O2
-DEPS=server.h connection.h config_parser.h request.h response.h request_handler.h echo_handler.h static_handler.h not_found_handler.h status_handler.h reverse_proxy_handler.h http_client.h sleep_handler.h markdown.h markdown-tokens.h
-OBJ=server.o connection.o config_parser.o request.o response.o request_handler.o echo_handler.o static_handler.o not_found_handler.o status_handler.o reverse_proxy_handler.o http_client.o sleep_handler.o markdown.o markdown-tokens.o
+DEPS=server.h connection.h config_parser.h request.h response.h request_handler.h echo_handler.h static_handler.h not_found_handler.h status_handler.h reverse_proxy_handler.h http_client.h sleep_handler.h markdown.h markdown-tokens.h markdown_handler.h
+OBJ=server.o connection.o config_parser.o request.o response.o request_handler.o echo_handler.o static_handler.o not_found_handler.o status_handler.o reverse_proxy_handler.o http_client.o sleep_handler.o markdown.o markdown-tokens.o markdown_handler.o
 GTEST_DIR=googletest/googletest
 TESTS=config_parser_test connection_test server_test request_test echo_handler_test static_handler_test not_found_handler_test request_handler_test status_handler_test reverse_proxy_handler_test http_client_test response_test
 DEPLOYS=deploy binary.tar webserver-image

--- a/config
+++ b/config
@@ -6,7 +6,6 @@ port 8080;
 threads 8; 
 
 path /echo EchoHandler {}
-path /test EchoHandler {}
 
 path /static/same StaticHandler {
 	root static;
@@ -40,7 +39,7 @@ path /proxy3 ReverseProxyHandler {
 
 # MarkdownFileHandler inherits StaticHandler, converts the loaded md file into html
 path_regex /regex .md StaticHandler {
-	root /static;
+	root static;
 }
 
 # Default response handler if no handlers match.

--- a/config
+++ b/config
@@ -38,5 +38,10 @@ path /proxy3 ReverseProxyHandler {
 	proxy_pass http://ucla.edu;
 }
 
+# MarkdownFileHandler inherits StaticHandler, converts the loaded md file into html
+path_regex /regex .md StaticHandler {
+	root /static;
+}
+
 # Default response handler if no handlers match.
 default NotFoundHandler {}

--- a/config
+++ b/config
@@ -37,7 +37,7 @@ path /proxy3 ReverseProxyHandler {
 	proxy_pass http://ucla.edu;
 }
 
-# MarkdownFileHandler inherits StaticHandler, converts the loaded md file into html
+# MarkdownHandler inherits StaticHandler, converts the loaded md file into html
 path_regex /static \.md MarkdownHandler {
 	root static;
 }

--- a/config
+++ b/config
@@ -38,7 +38,7 @@ path /proxy3 ReverseProxyHandler {
 }
 
 # MarkdownFileHandler inherits StaticHandler, converts the loaded md file into html
-path_regex /regex .md StaticHandler {
+path_regex /static \.md MarkdownHandler {
 	root static;
 }
 

--- a/connection.cc
+++ b/connection.cc
@@ -77,7 +77,7 @@ void Connection::handle_request(const boost::system::error_code& error, size_t b
 			request_summary_ = request->uri();
 
 			// get the correct handler based on the header
-			const RequestHandler* handler = GetRequestHandler(request->uri());
+			const RequestHandler* handler = handlers_->Find(request->uri());
 
 			if (handler == nullptr) {
 				// TODO generalize, fit with the StaticHandler
@@ -142,42 +142,6 @@ void Connection::close_socket(const boost::system::error_code& error)
 	
 	delete this;
 	BOOST_LOG_TRIVIAL(trace) << "======conection closed===========";
-}
-
-// returns a request handler if it was defined in the config, otherwise returns nullptr
-const RequestHandler* Connection::GetRequestHandler(const std::string& path)
-{
-	//exact match
-	std::map<const std::string, RequestHandler*>::const_iterator match = handlers_->find(path);
-	if(match != handlers_->end())
-		return match->second;
-
-	//longest prefix match
-	std::string prefix = get_prefix(path);
-	match = handlers_->find(prefix);
-	if(match != handlers_->end())
-		return match->second;
-
-	return nullptr;
-}
-
-// gets longest matching prefix
-std::string Connection::get_prefix(const std::string uri)
-{
-	std::string longest = "";
-	size_t index = uri.find_last_of("/");
-	std::string prefix = uri.substr(0, index);
-
-	for (auto& handlerPair : *handlers_)
-	{
-		std::string uri_key = handlerPair.first;
-
-		//uri_key is within this prefix
-		if(prefix.find(uri_key) == 0 && uri_key.length() > longest.length())
-			longest = uri_key;
-	}
-
-	return longest;
 }
 
 std::string Connection::GetStatus()

--- a/connection.h
+++ b/connection.h
@@ -42,12 +42,6 @@ private:
 	// Close socket after sending response
 	void close_socket(const boost::system::error_code& error);
 
-	// returns a request handler if it was defined in the config, otherwise returns nullptr
-	const RequestHandler* GetRequestHandler(const std::string & path);
-
-	// gets longest matching prefix
-	std::string get_prefix(const std::string uri);
-
 	tcp::socket socket_;
 	enum { max_length = 8192 }; // 8KB max length
 	boost::asio::streambuf data_stream_;

--- a/markdown_handler.cc
+++ b/markdown_handler.cc
@@ -1,0 +1,15 @@
+#include <sstream>
+#include "markdown_handler.h"
+
+bool MarkdownHandler::ProcessFile(const std::string& path, const std::string& data, std::string *new_data, std::string *content_type) const {
+
+	std::ostringstream out;
+	markdown::Document doc;
+	doc.read(data);
+	doc.write(out);
+
+	*new_data = out.str();
+	*content_type = "text/html";
+
+	return true;
+}

--- a/markdown_handler.h
+++ b/markdown_handler.h
@@ -1,0 +1,16 @@
+#ifndef MARKDOWN_HANDLER_H
+#define MARKDOWN_HANDLER_H
+
+#include <string>
+#include "request_handler.h"
+#include "static_handler.h"
+#include "markdown.h"
+
+class MarkdownHandler : public StaticHandler {
+protected:
+	virtual bool ProcessFile(const std::string& path, const std::string& data, std::string *new_data, std::string *content_type) const;
+};
+
+REGISTER_REQUEST_HANDLER(MarkdownHandler);
+
+#endif // MARKDOWN_HANDLER_H

--- a/request_handler.cc
+++ b/request_handler.cc
@@ -32,7 +32,6 @@ bool HandlerContainer::AddRegexPath(const std::string& prefix, const std::string
 }
 
 const RequestHandler* HandlerContainer::Find(const std::string& path) const {
-
 	// scan the regex paths for matches
 	// longest prefix match the list
 	size_t longest = 0;
@@ -45,18 +44,19 @@ const RequestHandler* HandlerContainer::Find(const std::string& path) const {
 		}
 	}
 
-	printf("longest regex match: %zu, %s\n", longest, longest_prefix.c_str());
+	//printf("longest regex match: %zu, %s\n", longest, longest_prefix.c_str());
 	// scan through again, this time applying the regex condition
 	if (longest_prefix != ""){
 		for (auto& tuple : regex_paths_) {
 			if (path.find(longest_prefix) == 0) {
 				//printf("testing regex match: %s\n", );
 				// TODO: save the regex parse to save time later
+				// TODO: do error checking
 				std::smatch m;
 				std::regex re(std::get<1>(tuple));
 
 				if (std::regex_search(path, m, re)){
-					printf("handler %p\n", std::get<2>(tuple).get());
+					//printf("handler %p\n", std::get<2>(tuple).get());
 					return std::get<2>(tuple).get();
 				}
 			}

--- a/request_handler.cc
+++ b/request_handler.cc
@@ -17,3 +17,62 @@ RequestHandler* RequestHandler::CreateByName(const std::string& type) {
 	}
 	return (*type_and_builder->second)();
 }
+
+
+
+bool HandlerContainer::AddPath(const std::string& prefix, const RequestHandler* handler){
+	auto insert_result = paths_.insert(std::make_pair(prefix, std::unique_ptr<const RequestHandler>(handler)));
+	return insert_result.second;
+}
+
+const RequestHandler* HandlerContainer::Find(const std::string& path) const {
+
+	// scan the regex paths for matches
+	// TODO
+
+	// scan the non-regex paths for matches
+
+	//exact match
+	auto match = paths_.find(path);
+	if(match != paths_.end())
+		return match->second.get();
+
+	//longest prefix match
+	std::string prefix = get_prefix(path);
+	match = paths_.find(prefix);
+	if(match != paths_.end())
+		return match->second.get();
+
+	// couldn't find anything
+	return nullptr;
+}
+
+std::list<std::string> HandlerContainer::GetList() const{
+	std::list<std::string> list;
+	for (const auto& pair : paths_) {
+		list.push_back(pair.first);
+	}
+	for (const auto& pair : regex_paths_) {
+		list.push_back(pair.first);
+	}
+	return list;
+}
+
+// gets longest matching prefix
+std::string HandlerContainer::get_prefix(const std::string& uri) const 
+{
+	std::string longest = "";
+	size_t index = uri.find_last_of("/");
+	std::string prefix = uri.substr(0, index);
+
+	for (auto& handlerPair : paths_)
+	{
+		std::string uri_key = handlerPair.first;
+
+		//uri_key is within this prefix
+		if(prefix.find(uri_key) == 0 && uri_key.length() > longest.length())
+			longest = uri_key;
+	}
+
+	return longest;
+}

--- a/request_handler.cc
+++ b/request_handler.cc
@@ -44,14 +44,19 @@ const RequestHandler* HandlerContainer::Find(const std::string& path) const {
 			longest_prefix = s;
 		}
 	}
+
 	printf("longest regex match: %zu, %s\n", longest, longest_prefix.c_str());
 	// scan through again, this time applying the regex condition
 	if (longest_prefix != ""){
 		for (auto& tuple : regex_paths_) {
 			if (path.find(longest_prefix) == 0) {
-				printf("testing regex match: %s\n", );
+				//printf("testing regex match: %s\n", );
 				// TODO: save the regex parse to save time later
-				if (std::regex_match(path, std::regex(std::get<1>(tuple)))){
+				std::smatch m;
+				std::regex re(std::get<1>(tuple));
+
+				if (std::regex_search(path, m, re)){
+					printf("handler %p\n", std::get<2>(tuple).get());
 					return std::get<2>(tuple).get();
 				}
 			}
@@ -85,7 +90,7 @@ std::list<std::string> HandlerContainer::GetList() const{
 }
 
 // gets longest matching prefix
-std::string HandlerContainer::get_prefix(const std::string& uri) const 
+std::string HandlerContainer::get_prefix(const std::string& uri) const
 {
 	std::string longest = "";
 	size_t index = uri.find_last_of("/");

--- a/request_handler.cc
+++ b/request_handler.cc
@@ -1,6 +1,7 @@
 #include <string>
 #include <map>
 #include <memory>
+#include <regex>
 
 #include "request_handler.h"
 #include "echo_handler.h"
@@ -19,24 +20,49 @@ RequestHandler* RequestHandler::CreateByName(const std::string& type) {
 }
 
 
-
 bool HandlerContainer::AddPath(const std::string& prefix, const RequestHandler* handler){
 	auto insert_result = paths_.insert(std::make_pair(prefix, std::unique_ptr<const RequestHandler>(handler)));
 	return insert_result.second;
 }
 
+bool HandlerContainer::AddRegexPath(const std::string& prefix, const std::string& regex, const RequestHandler* handler){
+	//auto insert_result = paths_.insert(std::make_pair(prefix, std::unique_ptr<const RequestHandler>(handler)));
+	regex_paths_.push_back(std::make_tuple(prefix, regex, std::unique_ptr<const RequestHandler>(handler)));
+	return true; // TODO: duplicate checking?
+}
+
 const RequestHandler* HandlerContainer::Find(const std::string& path) const {
 
 	// scan the regex paths for matches
-	// TODO
+	// longest prefix match the list
+	size_t longest = 0;
+	std::string longest_prefix = "";
+	for (auto& tuple : regex_paths_){
+		std::string s = std::get<0>(tuple);
+		if (path.find(s) == 0 && s.size() > longest) {
+			longest = s.size();
+			longest_prefix = s;
+		}
+	}
+	printf("longest regex match: %zu, %s\n", longest, longest_prefix.c_str());
+	// scan through again, this time applying the regex condition
+	if (longest_prefix != ""){
+		for (auto& tuple : regex_paths_) {
+			if (path.find(longest_prefix) == 0) {
+				printf("testing regex match: %s\n", );
+				// TODO: save the regex parse to save time later
+				if (std::regex_match(path, std::regex(std::get<1>(tuple)))){
+					return std::get<2>(tuple).get();
+				}
+			}
+		}
+	}
 
 	// scan the non-regex paths for matches
-
 	//exact match
 	auto match = paths_.find(path);
 	if(match != paths_.end())
 		return match->second.get();
-
 	//longest prefix match
 	std::string prefix = get_prefix(path);
 	match = paths_.find(prefix);
@@ -52,8 +78,8 @@ std::list<std::string> HandlerContainer::GetList() const{
 	for (const auto& pair : paths_) {
 		list.push_back(pair.first);
 	}
-	for (const auto& pair : regex_paths_) {
-		list.push_back(pair.first);
+	for (const auto& tuple : regex_paths_) {
+		list.push_back(std::get<0>(tuple) + " " + std::get<1>(tuple));
 	}
 	return list;
 }
@@ -76,3 +102,4 @@ std::string HandlerContainer::get_prefix(const std::string& uri) const
 
 	return longest;
 }
+

--- a/request_handler.cc
+++ b/request_handler.cc
@@ -1,7 +1,7 @@
 #include <string>
 #include <map>
 #include <memory>
-#include <regex>
+#include <boost/regex.hpp>
 #include <boost/log/trivial.hpp>
 
 #include "request_handler.h"
@@ -30,7 +30,7 @@ bool HandlerContainer::AddRegexPath(const std::string& prefix, const std::string
 	//auto insert_result = paths_.insert(std::make_pair(prefix, std::unique_ptr<const RequestHandler>(handler)));
 	// does the regex even compile?
 	try {
-		regex_paths_.push_back(std::make_tuple(prefix, regex, std::unique_ptr<const RequestHandler>(handler), std::regex(regex)));
+		regex_paths_.push_back(std::make_tuple(prefix, regex, std::unique_ptr<const RequestHandler>(handler), boost::regex(regex)));
 		return true; // TODO: duplicate checking?
 	}
 	catch (const std::exception& e){
@@ -51,13 +51,14 @@ const RequestHandler* HandlerContainer::Find(const std::string& path) const {
 			longest_prefix = s;
 		}
 	}
+	//printf("longest regex match: %d, %s\n", longest, longest_prefix.c_str());
 	// scan through again, this time applying the regex condition
 	if (longest > -1){
 		for (auto& tuple : regex_paths_) {
 			if (std::get<0>(tuple) == longest_prefix) {
-				std::smatch m;
-
-				if (std::regex_search(path, m, std::get<3>(tuple))){
+				boost::smatch m;
+				//printf("%s ok %s %s\n", path.c_str(), std::get<0>(tuple).c_str(), std::get<1>(tuple).c_str());
+				if (boost::regex_search(path, m, std::get<3>(tuple))){
 					BOOST_LOG_TRIVIAL(trace) << "regex path: " << std::get<0>(tuple) << " " << std::get<1>(tuple) << " matches " << path;
 					return std::get<2>(tuple).get();
 				}

--- a/request_handler.cc
+++ b/request_handler.cc
@@ -42,28 +42,23 @@ bool HandlerContainer::AddRegexPath(const std::string& prefix, const std::string
 const RequestHandler* HandlerContainer::Find(const std::string& path) const {
 	// scan the regex paths for matches
 	// longest prefix match the list
-	size_t longest = 0;
+	int longest = -1;
 	std::string longest_prefix = "";
 	for (auto& tuple : regex_paths_){
 		std::string s = std::get<0>(tuple);
-		if (path.find(s) == 0 && s.size() > longest) {
+		if (path.find(s) == 0 && (int)s.size() > longest) {
 			longest = s.size();
 			longest_prefix = s;
 		}
 	}
-
-	//printf("longest regex match: %zu, %s\n", longest, longest_prefix.c_str());
 	// scan through again, this time applying the regex condition
-	if (longest_prefix != ""){
+	if (longest > -1){
 		for (auto& tuple : regex_paths_) {
-			if (path.find(longest_prefix) == 0) {
-				//printf("testing regex match: %s\n", );
-				// TODO: save the regex parse to save time later
-				// TODO: do error checking
+			if (std::get<0>(tuple) == longest_prefix) {
 				std::smatch m;
 
 				if (std::regex_search(path, m, std::get<3>(tuple))){
-					//printf("handler %p\n", std::get<2>(tuple).get());
+					BOOST_LOG_TRIVIAL(trace) << "regex path: " << std::get<0>(tuple) << " " << std::get<1>(tuple) << " matches " << path;
 					return std::get<2>(tuple).get();
 				}
 			}

--- a/request_handler.h
+++ b/request_handler.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <map>
+#include <list>
 #include <memory>
 #include "request.h"
 #include "response.h"
@@ -31,9 +32,6 @@ public:
 	virtual RequestHandler::Status HandleRequest(const Request& request, Response* response) const = 0;
 };
 
-// map of k,v pairs, where k = path and v = pointer to request handler
-typedef std::map<const std::string, RequestHandler*> HandlerContainer;
-
 // Notes:
 // * The trick here is that you can declare an object at file scope, but you
 //   can't do anything else, such as set a map key. But you can get around this
@@ -57,5 +55,29 @@ public:
 };
 
 #define REGISTER_REQUEST_HANDLER(ClassName) static RequestHandlerRegisterer<ClassName> ClassName##__registerer(#ClassName)
+
+
+// Enapsulates prefix path searching, regex searching
+// Hides the internal storage structure for handlers
+// Calling Add gives ownership to this container
+class HandlerContainer {
+public:
+	bool AddPath(const std::string& prefix, const RequestHandler* handler);
+	bool AddRegexPath(const std::string& prefix, const std::string& regex, const RequestHandler* handler);
+
+	// returns a request handler if it was defined in the config, otherwise returns nullptr
+	const RequestHandler* Find(const std::string& path) const;
+
+	// returns a list of request handler paths (for the status page)
+	std::list<std::string> GetList() const;
+
+private:
+	// gets longest matching prefix
+	std::string get_prefix(const std::string& uri) const;
+
+	std::map<const std::string, std::unique_ptr<const RequestHandler>> paths_;
+	std::map<const std::string, std::pair<const std::string, std::unique_ptr<const RequestHandler>>> regex_paths_;
+};
+
 
 #endif // REQUEST_HANDLER_H

--- a/request_handler.h
+++ b/request_handler.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <list>
 #include <memory>
+#include <tuple>
 #include "request.h"
 #include "response.h"
 #include "config_parser.h"
@@ -76,7 +77,9 @@ private:
 	std::string get_prefix(const std::string& uri) const;
 
 	std::map<const std::string, std::unique_ptr<const RequestHandler>> paths_;
-	std::map<const std::string, std::pair<const std::string, std::unique_ptr<const RequestHandler>>> regex_paths_;
+	std::list<std::tuple<const std::string, const std::string, std::unique_ptr<const RequestHandler>>> regex_paths_;
+	//std::map<const std::string, std::pair<const std::string, std::unique_ptr<const RequestHandler>>> regex_paths_;
+	//std::multimap<const std::string, std::pair<const std::string, std::unique_ptr<const RequestHandler>>> regex_paths_;
 };
 
 

--- a/request_handler.h
+++ b/request_handler.h
@@ -6,6 +6,7 @@
 #include <list>
 #include <memory>
 #include <tuple>
+#include <regex>
 #include "request.h"
 #include "response.h"
 #include "config_parser.h"
@@ -77,7 +78,7 @@ private:
 	std::string get_prefix(const std::string& uri) const;
 
 	std::map<const std::string, std::unique_ptr<const RequestHandler>> paths_;
-	std::list<std::tuple<const std::string, const std::string, std::unique_ptr<const RequestHandler>>> regex_paths_;
+	std::list<std::tuple<const std::string, const std::string, std::unique_ptr<const RequestHandler>, std::regex>> regex_paths_;
 };
 
 

--- a/request_handler.h
+++ b/request_handler.h
@@ -6,7 +6,7 @@
 #include <list>
 #include <memory>
 #include <tuple>
-#include <regex>
+#include <boost/regex.hpp>
 #include "request.h"
 #include "response.h"
 #include "config_parser.h"
@@ -86,7 +86,7 @@ private:
 
 	std::map<const std::string, std::unique_ptr<const RequestHandler>> paths_;
 	// {path, regex string, handler*, compiled regex}
-	std::list<std::tuple<const std::string, const std::string, std::unique_ptr<const RequestHandler>, std::regex>> regex_paths_;
+	std::list<std::tuple<const std::string, const std::string, std::unique_ptr<const RequestHandler>, boost::regex>> regex_paths_;
 };
 
 

--- a/request_handler.h
+++ b/request_handler.h
@@ -78,8 +78,6 @@ private:
 
 	std::map<const std::string, std::unique_ptr<const RequestHandler>> paths_;
 	std::list<std::tuple<const std::string, const std::string, std::unique_ptr<const RequestHandler>>> regex_paths_;
-	//std::map<const std::string, std::pair<const std::string, std::unique_ptr<const RequestHandler>>> regex_paths_;
-	//std::multimap<const std::string, std::pair<const std::string, std::unique_ptr<const RequestHandler>>> regex_paths_;
 };
 
 

--- a/request_handler.h
+++ b/request_handler.h
@@ -61,16 +61,23 @@ public:
 
 // Enapsulates prefix path searching, regex searching
 // Hides the internal storage structure for handlers
-// Calling Add gives ownership to this container
+
 class HandlerContainer {
 public:
+	// Tracks a handler + prefix
+	// - Calling Add gives ownership to this container
+	// - Duplicate AddPath prefixes are not allowed
 	bool AddPath(const std::string& prefix, const RequestHandler* handler);
 	bool AddRegexPath(const std::string& prefix, const std::string& regex, const RequestHandler* handler);
 
 	// returns a request handler if it was defined in the config, otherwise returns nullptr
+	// - longest matching prefix match
+	// - regex paths take priority over regular paths
+	// - picks the first regex match (after the longest match prefix)
 	const RequestHandler* Find(const std::string& path) const;
 
 	// returns a list of request handler paths (for the status page)
+	// - path in alphabetical order, then path_regex in alphabetical order
 	std::list<std::string> GetList() const;
 
 private:
@@ -78,6 +85,7 @@ private:
 	std::string get_prefix(const std::string& uri) const;
 
 	std::map<const std::string, std::unique_ptr<const RequestHandler>> paths_;
+	// {path, regex string, handler*, compiled regex}
 	std::list<std::tuple<const std::string, const std::string, std::unique_ptr<const RequestHandler>, std::regex>> regex_paths_;
 };
 

--- a/request_handler_test.cc
+++ b/request_handler_test.cc
@@ -1,3 +1,5 @@
+#include <string>
+#include <iostream>
 #include "gtest/gtest.h"
 #include "request_handler.h"
 #include "echo_handler.h"
@@ -10,4 +12,67 @@ TEST(RequestHandlerTest, SimpleCreate) {
 TEST(RequestHandlerTest, BadCreate) {
 	RequestHandler* handler = RequestHandler::CreateByName("BadHandler");
 	ASSERT_FALSE(handler);
+}
+
+TEST(RequestHandlerTest, SimpleAddHandler) {
+
+	HandlerContainer handlers;
+
+	// use real pointers
+	RequestHandler* x = RequestHandler::CreateByName("EchoHandler");
+	RequestHandler* y = RequestHandler::CreateByName("EchoHandler");
+	RequestHandler* z = RequestHandler::CreateByName("EchoHandler");
+	RequestHandler* w = RequestHandler::CreateByName("EchoHandler");
+
+	ASSERT_TRUE(handlers.AddPath("/prefix1", x));
+	ASSERT_TRUE(handlers.AddPath("/prefix2", y));
+	ASSERT_FALSE(handlers.AddPath("/prefix2", w));
+
+	EXPECT_EQ(handlers.Find("/prefix1"), x);
+	EXPECT_EQ(handlers.Find("/prefix2"), y);
+	EXPECT_EQ(handlers.Find("/nothing"), nullptr);
+
+	// empty path
+	ASSERT_TRUE(handlers.AddPath("", z)); // use "" for the default
+	EXPECT_EQ(handlers.Find(""), z);
+	EXPECT_EQ(handlers.Find("/nothing"), z);
+
+	// alphabetical order
+	EXPECT_EQ(handlers.GetList(), std::list<std::string>({"","/prefix1","/prefix2"}));
+}
+
+
+TEST(RequestHandlerTest, AddHandlerRegex) {
+
+	HandlerContainer handlers;
+
+	// use real pointers
+	RequestHandler* x = RequestHandler::CreateByName("EchoHandler");
+	RequestHandler* y = RequestHandler::CreateByName("EchoHandler");
+	RequestHandler* z = RequestHandler::CreateByName("EchoHandler");
+	RequestHandler* w = RequestHandler::CreateByName("EchoHandler");
+	RequestHandler* v = RequestHandler::CreateByName("EchoHandler");
+
+	ASSERT_TRUE(handlers.AddPath("/prefix1", x));
+	ASSERT_TRUE(handlers.AddRegexPath("/prefix1", "\\.lua", y));
+	ASSERT_TRUE(handlers.AddRegexPath("/prefix1", "lua", z));
+	ASSERT_TRUE(handlers.AddRegexPath("/foo", ".*", w));
+	ASSERT_FALSE(handlers.AddRegexPath("/prefix2", "[.lua", v)); // regex mismatched [
+	
+	// TODO: this is probably going to change soon anyway
+	std::list<std::string> list = handlers.GetList();
+	// EXPECT_EQ(list, {
+	// 	"/prefix1",
+	// });
+
+	EXPECT_EQ(handlers.Find("/prefix1"), x);
+	EXPECT_EQ(handlers.Find("/prefix1/cats.lua"), y); // matches y, but not x
+	EXPECT_EQ(handlers.Find("/prefix1/catslua"),z);
+	EXPECT_EQ(handlers.Find("anything"), nullptr);
+	EXPECT_EQ(handlers.Find("/foo/anything"), w); // .* doesn't match due to prefix
+
+	// empty path
+	ASSERT_TRUE(handlers.AddRegexPath("", ".*", v));
+	EXPECT_EQ(handlers.Find("anything"), v); // matches "" prefix and .*
+
 }

--- a/server.cc
+++ b/server.cc
@@ -169,7 +169,7 @@ bool Server::parse_config(const NginxConfig& config, int& port, HandlerContainer
 			}
 
 			if (!handlers->AddRegexPath(statement->tokens_[1], statement->tokens_[2], handler)){
-				BOOST_LOG_TRIVIAL(fatal) << "Duplicate handler uri detected at " << statement->tokens_[1] << " " << statement->tokens_[2];
+				BOOST_LOG_TRIVIAL(fatal) << "Error creating handler " << statement->tokens_[1] << " " << statement->tokens_[2];
 				return false;
 			}
 

--- a/server.cc
+++ b/server.cc
@@ -116,6 +116,10 @@ bool Server::parse_config(const NginxConfig& config, int& port, HandlerContainer
 			//default handler
 			else if(statement->tokens_[0] == "default" && statement->child_block_ != nullptr) {
 				RequestHandler* handler = RequestHandler::CreateByName(statement->tokens_[1]);
+				if(!handler){
+					BOOST_LOG_TRIVIAL(fatal) << "Invalid handler type: " << statement->tokens_[3];
+					return false;
+				}
 				std::string empty_string = "";
 				if(handler->Init(empty_string, *(statement->child_block_).get()) == RequestHandler::ERROR)
 				{
@@ -136,6 +140,10 @@ bool Server::parse_config(const NginxConfig& config, int& port, HandlerContainer
 				statement->tokens_[0] == "path" &&
 				statement->child_block_ != nullptr) {
 			RequestHandler* handler = RequestHandler::CreateByName(statement->tokens_[2]);
+			if(!handler){
+				BOOST_LOG_TRIVIAL(fatal) << "Invalid handler type: " << statement->tokens_[3];
+				return false;
+			}
 
 			if(handler->Init(statement->tokens_[1], *(statement->child_block_).get()) == RequestHandler::ERROR)
 			{
@@ -160,7 +168,10 @@ bool Server::parse_config(const NginxConfig& config, int& port, HandlerContainer
 				statement->tokens_[0] == "path_regex" &&
 				statement->child_block_ != nullptr) {
 			RequestHandler* handler = RequestHandler::CreateByName(statement->tokens_[3]);
-			printf("created handler %p\n", handler);
+			if(!handler){
+				BOOST_LOG_TRIVIAL(fatal) << "Invalid handler type: " << statement->tokens_[3];
+				return false;
+			}
 
 			if(handler->Init(statement->tokens_[1], *(statement->child_block_).get()) == RequestHandler::ERROR)
 			{

--- a/server.cc
+++ b/server.cc
@@ -9,8 +9,8 @@
 #include "server.h"
 #include "config_parser.h"
 #include "request_handler.h"
-#include "echo_handler.h"
-#include "static_handler.h"
+//#include "echo_handler.h"
+//#include "static_handler.h"
 #include "not_found_handler.h"
 #include "status_handler.h"
 

--- a/server.cc
+++ b/server.cc
@@ -160,6 +160,7 @@ bool Server::parse_config(const NginxConfig& config, int& port, HandlerContainer
 				statement->tokens_[0] == "path_regex" &&
 				statement->child_block_ != nullptr) {
 			RequestHandler* handler = RequestHandler::CreateByName(statement->tokens_[3]);
+			printf("created handler %p\n", handler);
 
 			if(handler->Init(statement->tokens_[1], *(statement->child_block_).get()) == RequestHandler::ERROR)
 			{

--- a/static_handler.cc
+++ b/static_handler.cc
@@ -87,8 +87,6 @@ bool StaticHandler::ProcessFile(const std::string& path, const std::string& data
 	
 		auto it = content_mappings.find(file_extension);
 		if (it != content_mappings.end()) {
-			printf("found content type %s\n", it->second.c_str());
-
 			*content_type = it->second;
 		}
 	}

--- a/static_handler.cc
+++ b/static_handler.cc
@@ -63,8 +63,9 @@ RequestHandler::Status StaticHandler::HandleRequest(const Request& request, Resp
 			response->AddHeader("Content-Type", content_type);
 		}
 
-		response->AddHeader("Content-Length", std::to_string(body_data.length()));
+		response->AddHeader("Content-Length", std::to_string(new_data.length()));
 		response->SetBody(new_data);
+
 		response->SetStatus(Response::ok);
 	}
 	else {

--- a/static_handler.h
+++ b/static_handler.h
@@ -13,6 +13,9 @@ public:
 	RequestHandler::Status Init(const std::string& uri_prefix, const NginxConfig& config);
 	virtual RequestHandler::Status HandleRequest(const Request& request, Response* response) const;
 
+protected:
+	virtual bool ProcessFile(const std::string& path, const std::string& data, std::string *new_data, std::string *content_type) const;
+
 private:
 	// max buffer length for reading in file stream
 	enum { max_length = 8192 };


### PR DESCRIPTION
- Added path_regex to the config
    - path_regex has priority over path
    - ecmascript syntax
    - path_regex <prefix> <regex> <handler type> {<config block>}
- Refactored HandlerContainer into its own class
- Refactored StaticHandler to be easily inheritable
- Refactored markdown conversion into its own handler MarkdownHandler
    ``` 
    path_regex /static \.md MarkdownHandler {
        root static;
    } 
    ```
Known issues:
- our config parser doesn't have escape sequences, so {} and quotes don't work
- that static file handler gives blank pages for folders now
